### PR TITLE
Fix #1 Fix name of the bin in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,5 @@
     "test": "mocha -R spec"
   },
   "preferGlobal": true,
-  "bin": {
-    "server": "./bin/server"
-  }
+  "bin": "./bin/crest"
 }


### PR DESCRIPTION
I think #1 is caused by  the difference between a file name in the bin directory and the command name in the package.json.
