### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Recommended way to run mocha in terminal with mocha reporter _spec_ chosen.
 More indepth tests will be added at a later date. 
 
 
-##Bugs
+## Bugs
 
 Issues can be found at [https://github.com/cordazar/crest/issues](https://github.com/cordazar/crest/issues)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
