### PR TITLE
Update mongodb package for MongoDB 3.4.4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/Cordazar/crest/issues"
   },
   "dependencies": {
-    "mongodb": "1.2.x",
+    "mongodb": "latest",
     "restify": "2.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the version of mongodb package to "latest" to support
MongoDB server 3.4.4 and plus.