### PR TITLE
Fixed Enoent error with npm install -g

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "preferGlobal": true,
   "bin": {
-    "server": "./bin/server"
+    "server": "./bin/crest"
   }
 }


### PR DESCRIPTION
In package.json, I switched 
"server": "./bin/server"
with 
"server": "./bin/crest"
This will fix installation issues that a lot of people have run into, referenced in other Issues. Hope this helps!